### PR TITLE
Phase 3: New Features - Naming, Buzzer, OLED, Achievements, Pet Types

### DIFF
--- a/Achievements.cpp
+++ b/Achievements.cpp
@@ -1,0 +1,103 @@
+#include "Achievements.h"
+#include "config.h"
+#include <SPIFFS.h>
+#include <ArduinoJson.h>
+
+void loadAchievements(Pet &pet) {
+  if (!SPIFFS.exists(ACHIEVEMENTS_FILE)) {
+    Serial.println("No achievements file found, starting fresh");
+    return;
+  }
+
+  File file = SPIFFS.open(ACHIEVEMENTS_FILE, "r");
+  if (!file) {
+    Serial.println("Failed to open achievements file");
+    return;
+  }
+
+  DynamicJsonDocument jsonDoc(1024);
+  DeserializationError error = deserializeJson(jsonDoc, file);
+  if (error) {
+    Serial.println("Failed to parse achievements file");
+  } else {
+    pet.feedCount     = jsonDoc["feedCount"]     | 0;
+    pet.playCount     = jsonDoc["playCount"]     | 0;
+    pet.hasBeenNamed  = jsonDoc["hasBeenNamed"]  | false;
+    pet.elderAchieved = jsonDoc["elderAchieved"] | false;
+  }
+
+  file.close();
+}
+
+void saveAchievements(const Pet &pet) {
+  File file = SPIFFS.open(ACHIEVEMENTS_FILE, "w");
+  if (!file) {
+    Serial.println("Failed to open achievements file for writing");
+    return;
+  }
+
+  DynamicJsonDocument jsonDoc(1024);
+  jsonDoc["feedCount"]     = pet.feedCount;
+  jsonDoc["playCount"]     = pet.playCount;
+  jsonDoc["hasBeenNamed"]  = pet.hasBeenNamed;
+  jsonDoc["elderAchieved"] = pet.elderAchieved;
+
+  if (serializeJson(jsonDoc, file) == 0) {
+    Serial.println("Failed to write achievements");
+  }
+
+  file.close();
+}
+
+void checkAchievements(Pet &pet) {
+  if (!pet.isAlive) return;
+
+  // Survived 1 hour (age >= 60 minutes)
+  // Note: age is in minutes, so 60 = 1 hour
+
+  // Survived 24 hours (age >= 1440 minutes)
+
+  // Fed 10 times
+  if (pet.feedCount >= 10) {
+    Serial.println("Achievement: Fed 10x");
+  }
+
+  // Played 10 times
+  if (pet.playCount >= 10) {
+    Serial.println("Achievement: Played 10x");
+  }
+
+  // Named pet
+  if (pet.hasBeenNamed) {
+    Serial.println("Achievement: Named Pet");
+  }
+
+  // Reached elder stage
+  if (pet.stage == ELDER && !pet.elderAchieved) {
+    pet.elderAchieved = true;
+    Serial.println("Achievement: Reached Elder!");
+    saveAchievements(pet);
+  }
+}
+
+String getAchievementsJson(const Pet &pet) {
+  DynamicJsonDocument jsonDoc(1024);
+  JsonArray arr = jsonDoc.createNestedArray("achievements");
+
+  // survived_1h
+  if (pet.age >= 60) arr.add(ACH_SURVIVED_1H);
+  // survived_24h
+  if (pet.age >= 1440) arr.add(ACH_SURVIVED_24H);
+  // fed_10x
+  if (pet.feedCount >= 10) arr.add(ACH_FED_10X);
+  // played_10x
+  if (pet.playCount >= 10) arr.add(ACH_PLAYED_10X);
+  // named_pet
+  if (pet.hasBeenNamed) arr.add(ACH_NAMED_PET);
+  // reached_elder
+  if (pet.elderAchieved || pet.stage == ELDER) arr.add(ACH_REACHED_ELDER);
+
+  String result;
+  serializeJson(jsonDoc, result);
+  return result;
+}

--- a/Achievements.h
+++ b/Achievements.h
@@ -1,0 +1,32 @@
+#ifndef ACHIEVEMENTS_H
+#define ACHIEVEMENTS_H
+
+#include <Arduino.h>
+#include "Pet.h"
+
+// ============================================================
+// Achievements System
+// Tracks milestones and persists to SPIFFS /achievements.json
+// ============================================================
+
+// Achievement IDs
+#define ACH_SURVIVED_1H     "survived_1h"
+#define ACH_SURVIVED_24H    "survived_24h"
+#define ACH_FED_10X         "fed_10x"
+#define ACH_PLAYED_10X      "played_10x"
+#define ACH_NAMED_PET       "named_pet"
+#define ACH_REACHED_ELDER   "reached_elder"
+
+#define ACHIEVEMENTS_FILE   "/achievements.json"
+
+// Load/save achievements from SPIFFS
+void loadAchievements(Pet &pet);
+void saveAchievements(const Pet &pet);
+
+// Check and unlock achievements (call after updatePet)
+void checkAchievements(Pet &pet);
+
+// Get achievements as JSON string
+String getAchievementsJson(const Pet &pet);
+
+#endif // ACHIEVEMENTS_H

--- a/ESP32-TamaPetchi.ino
+++ b/ESP32-TamaPetchi.ino
@@ -8,6 +8,11 @@
 #include "Storage.h"
 #include "WebHandlers.h"
 
+// OLED display (optional - enable with -DENABLE_OLED)
+#ifdef ENABLE_OLED
+#include "OLED.h"
+#endif
+
 // Web server
 WebServer server(WEB_SERVER_PORT);
 
@@ -50,6 +55,11 @@ void setup() {
 
   // Start server
   server.begin();
+
+  // Initialize OLED
+#ifdef ENABLE_OLED
+  setupOLED();
+#endif
 }
 
 void loop() {
@@ -61,5 +71,9 @@ void loop() {
     lastUpdateTime = currentMillis;
     updatePet(pet);
     savePetData(pet);
+
+#ifdef ENABLE_OLED
+    updateOLED(pet);
+#endif
   }
 }

--- a/ESP32-TamaPetchi.ino
+++ b/ESP32-TamaPetchi.ino
@@ -7,6 +7,7 @@
 #include "Pet.h"
 #include "Storage.h"
 #include "WebHandlers.h"
+#include "Achievements.h"
 
 // OLED display (optional - enable with -DENABLE_OLED)
 #ifdef ENABLE_OLED
@@ -28,7 +29,10 @@ String previousState = "";
 unsigned long lastUpdateTime = 0;
 
 void setup() {
-  Serial.begin(115200);
+  Serial.begin(SERIAL_BAUD);
+
+  // Initialize random seed
+  randomSeed(analogRead(0));
 
   // Initialize SPIFFS
   if (!SPIFFS.begin(true)) {
@@ -48,10 +52,11 @@ void setup() {
 
   // Load pet data from SPIFFS
   loadPetData(pet);
+  loadAchievements(pet);
   previousState = pet.state;
 
   // Register web server routes
-  setupWebServer(server, pet, showWakeMessage, wakeMessageStartTime, previousState);
+  registerHandlers(server, pet);
 
   // Start server
   server.begin();
@@ -70,6 +75,7 @@ void loop() {
   if (currentMillis - lastUpdateTime >= PET_UPDATE_INTERVAL) {
     lastUpdateTime = currentMillis;
     updatePet(pet);
+    checkAchievements(pet);
     savePetData(pet);
 
 #ifdef ENABLE_OLED

--- a/OLED.cpp
+++ b/OLED.cpp
@@ -1,0 +1,108 @@
+#include "OLED.h"
+#include "config.h"
+
+#ifdef ENABLE_OLED
+
+#include <Wire.h>
+#include <Adafruit_GFX.h>
+#include <Adafruit_SSD1306.h>
+
+#define SCREEN_WIDTH  128
+#define SCREEN_HEIGHT  64
+#define OLED_RESET     -1
+#define OLED_ADDRESS   0x3C
+
+static Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
+
+void setupOLED() {
+  Wire.begin(21, 22); // SDA=21, SCL=22
+  if (!display.begin(SSD1306_SWITCHCAPVCC, OLED_ADDRESS)) {
+    Serial.println("SSD1306 OLED allocation failed");
+    return;
+  }
+  display.clearDisplay();
+  display.setTextSize(1);
+  display.setTextColor(SSD1306_WHITE);
+  display.setCursor(0, 0);
+  display.println("TamaPetchi");
+  display.display();
+  Serial.println("OLED initialized");
+}
+
+void updateOLED(const Pet &pet) {
+  display.clearDisplay();
+
+  // Header: pet name + state
+  display.setTextSize(1);
+  display.setCursor(0, 0);
+  display.print(pet.name);
+  display.print(" - ");
+
+  // State text
+  if (!pet.isAlive) {
+    display.println("DEAD");
+  } else if (pet.state == "sleeping") {
+    display.println("Zzz...");
+  } else if (pet.state == "eating") {
+    display.println("Eating");
+  } else if (pet.state == "playing") {
+    display.println("Playing");
+  } else if (pet.state == "sick") {
+    display.println("Sick!");
+  } else if (pet.state == "hungry") {
+    display.println("Hungry!");
+  } else if (pet.state == "critical") {
+    display.println("Critical!");
+  } else if (pet.state == "dying") {
+    display.println("Dying!");
+  } else {
+    display.println("Happy");
+  }
+
+  // Separator line
+  display.drawLine(0, 10, SCREEN_WIDTH, 10, SSD1306_WHITE);
+
+  // Stat bars: hunger, health, energy
+  const char* labels[] = {"Hunger", "Health", "Energy"};
+  int values[] = {pet.hunger, pet.health, pet.energy};
+
+  for (int i = 0; i < 3; i++) {
+    int y = 14 + i * 16;
+    display.setCursor(0, y);
+    display.setTextSize(1);
+    display.print(labels[i]);
+    display.print(": ");
+    display.print(values[i]);
+    display.print("%");
+
+    // Bar background
+    int barX = 0;
+    int barY = y + 10;
+    int barW = SCREEN_WIDTH;
+    int barH = 4;
+    display.drawRect(barX, barY, barW, barH, SSD1306_WHITE);
+
+    // Bar fill
+    int fillW = (values[i] * barW) / 100;
+    if (fillW > 0) {
+      display.fillRect(barX, barY, fillW, barH, SSD1306_WHITE);
+    }
+  }
+
+  // Stage indicator at bottom
+  display.setCursor(0, 62);
+  display.setTextSize(1);
+  display.print("Age:");
+  display.print(pet.age);
+  display.print("m ");
+  switch (pet.stage) {
+    case BABY:  display.print("[Baby]");  break;
+    case CHILD: display.print("[Child]"); break;
+    case ADULT: display.print("[Adult]"); break;
+    case ELDER: display.print("[Elder]"); break;
+  }
+
+  display.display();
+}
+
+#endif // ENABLE_OLED

--- a/OLED.h
+++ b/OLED.h
@@ -1,0 +1,19 @@
+#ifndef OLED_H
+#define OLED_H
+
+#include <Arduino.h>
+#include "Pet.h"
+
+// ============================================================
+// OLED Display (SSD1306 128x64)
+// Wrapped in #ifdef ENABLE_OLED / #endif for optional compilation
+// ============================================================
+
+#ifdef ENABLE_OLED
+
+void setupOLED();
+void updateOLED(const Pet &pet);
+
+#endif // ENABLE_OLED
+
+#endif // OLED_H

--- a/Pet.cpp
+++ b/Pet.cpp
@@ -39,6 +39,7 @@ void updatePet(Pet &pet) {
     if (pet.energy >= STAT_MAX) {
       pet.state          = "normal";
       pet.stateChangeTime = millis();
+      if (pet.soundEnabled) soundWake();
       Serial.println("Pet woke up automatically after full rest");
     }
   } else {
@@ -93,6 +94,8 @@ void feedPet(Pet &pet) {
   pet.stateChangeTime    = millis();
   pet.lastInteractionTime = millis();
 
+  if (pet.soundEnabled) soundFeed();
+
   // If very hungry, improve health too
   if (pet.hunger < HEALTH_DECAY_THRESHOLD) {
     pet.health = clampStat(pet.health + FEED_HEALTH_BONUS);
@@ -109,6 +112,8 @@ void playPet(Pet &pet) {
   pet.state     = "playing";
   pet.stateChangeTime     = millis();
   pet.lastInteractionTime = millis();
+
+  if (pet.soundEnabled) soundPlay();
 }
 
 void cleanPet(Pet &pet) {
@@ -141,4 +146,35 @@ void healPet(Pet &pet) {
 
 void resetPet(Pet &pet) {
   initPet(pet);
+}
+
+
+// ============================================================
+// Sound Effects (Buzzer)
+// ============================================================
+
+void soundFeed() {
+  tone(BUZZER_PIN, 1000, 200);
+}
+
+void soundPlay() {
+  tone(BUZZER_PIN, 800, 100);
+  delay(150);
+  tone(BUZZER_PIN, 1200, 100);
+}
+
+void soundDeath() {
+  for (int freq = 1000; freq >= 200; freq -= 100) {
+    tone(BUZZER_PIN, freq, 50);
+    delay(60);
+  }
+  noTone(BUZZER_PIN);
+}
+
+void soundWake() {
+  for (int freq = 200; freq <= 1000; freq += 200) {
+    tone(BUZZER_PIN, freq, 60);
+    delay(80);
+  }
+  noTone(BUZZER_PIN);
 }

--- a/Pet.cpp
+++ b/Pet.cpp
@@ -1,4 +1,3 @@
-/usr/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
 #include "Pet.h"
 #include "config.h"
 
@@ -7,6 +6,72 @@ static int clampStat(int value) {
   if (value < STAT_MIN) return STAT_MIN;
   if (value > STAT_MAX) return STAT_MAX;
   return value;
+}
+
+// ============================================================
+// Randomness
+// ============================================================
+
+int randomVariation(int base) {
+  if (base == 0) return 0;
+  int variation = base * 20 / 100;  // 20%
+  if (variation == 0) variation = 1;
+  return base + random(-variation, variation + 1);
+}
+
+// ============================================================
+// Evolution Stages
+// ============================================================
+
+void updateStage(Pet &pet) {
+  if (pet.age <= BABY_MAX_MINUTES) {
+    pet.stage = BABY;
+  } else if (pet.age <= CHILD_MAX_MINUTES) {
+    pet.stage = CHILD;
+  } else if (pet.age <= ADULT_MAX_MINUTES) {
+    pet.stage = ADULT;
+  } else {
+    pet.stage = ELDER;
+  }
+}
+
+int getStageDecayMultiplier(Pet &pet) {
+  switch (pet.stage) {
+    case BABY:  return BABY_DECAY_MULT;
+    case CHILD: return CHILD_DECAY_MULT;
+    case ADULT: return ADULT_DECAY_MULT;
+    case ELDER: return ELDER_DECAY_MULT;
+    default:    return 100;
+  }
+}
+
+// ============================================================
+// Day/Night Cycle
+// ============================================================
+
+void updateDayNightCycle(Pet &pet) {
+  pet.virtualMinutes += PET_UPDATE_INTERVAL / 1000;
+  if (pet.virtualMinutes >= VIRTUAL_MINUTES_PER_DAY) {
+    pet.virtualMinutes = pet.virtualMinutes % VIRTUAL_MINUTES_PER_DAY;
+  }
+
+  bool wasNight = pet.isNight;
+  pet.isNight = isNightTime(pet.virtualMinutes);
+
+  if (pet.isNight && !wasNight) {
+    Serial.println("Night has fallen...");
+  }
+
+  if (pet.isNight && pet.energy < 50 && pet.state != "sleeping" && pet.state != "dead") {
+    pet.state = "sleeping";
+    pet.stateChangeTime = millis();
+    Serial.println("Pet went to sleep (night time, low energy)");
+  }
+}
+
+bool isNightTime(unsigned long virtualMin) {
+  unsigned long hour = (virtualMin / VIRTUAL_MINUTES_PER_HOUR) % 24;
+  return (hour >= NIGHT_START_HOUR || hour < DAY_START_HOUR);
 }
 
 // ============================================================
@@ -24,16 +89,45 @@ void initPet(Pet &pet) {
   pet.state           = "normal";
   pet.stateChangeTime      = millis();
   pet.lastInteractionTime  = millis();
+
+  // Phase 2 init
+  pet.stage           = BABY;
+  pet.isNight         = false;
+  pet.virtualMinutes  = 6 * VIRTUAL_MINUTES_PER_HOUR; // Start at 6:00 (morning)
+
+  // Phase 3 init
+  pet.name            = "Tama";
+  pet.soundEnabled    = true;
+
+  // Achievement tracking init
+  pet.feedCount       = 0;
+  pet.playCount       = 0;
+  pet.hasBeenNamed    = false;
+  pet.elderAchieved   = false;
 }
 
 void updatePet(Pet &pet) {
   if (!pet.isAlive) return;
 
+  // Update day/night cycle
+  updateDayNightCycle(pet);
+
+  // Update evolution stage
+  updateStage(pet);
+
+  // Get stage multiplier for decay rates
+  int mult = getStageDecayMultiplier(pet);
+
   if (pet.state == "sleeping") {
-    pet.hunger      = clampStat(pet.hunger      - HUNGER_DECAY_SLEEP);
-    pet.happiness   = clampStat(pet.happiness   - HAPPINESS_DECAY_SLEEP);
-    pet.energy      = clampStat(pet.energy      + ENERGY_REGEN_SLEEP);
-    pet.cleanliness = clampStat(pet.cleanliness - CLEANLINESS_DECAY_SLEEP);
+    int hungerDecay = randomVariation((HUNGER_DECAY_SLEEP * mult) / 100);
+    int happyDecay  = randomVariation(HAPPINESS_DECAY_SLEEP);
+    int energyRegen = randomVariation(ENERGY_REGEN_SLEEP);
+    int cleanDecay  = randomVariation(CLEANLINESS_DECAY_SLEEP);
+
+    pet.hunger      = clampStat(pet.hunger      - hungerDecay);
+    pet.happiness   = clampStat(pet.happiness   - happyDecay);
+    pet.energy      = clampStat(pet.energy      + energyRegen);
+    pet.cleanliness = clampStat(pet.cleanliness - cleanDecay);
 
     // Auto wake-up when energy is full
     if (pet.energy >= STAT_MAX) {
@@ -42,11 +136,23 @@ void updatePet(Pet &pet) {
       if (pet.soundEnabled) soundWake();
       Serial.println("Pet woke up automatically after full rest");
     }
+    // Wake up if it's daytime and energy >= 80
+    else if (!pet.isNight && pet.energy >= 80) {
+      pet.state          = "normal";
+      pet.stateChangeTime = millis();
+      if (pet.soundEnabled) soundWake();
+      Serial.println("Pet woke up with the sunrise");
+    }
   } else {
-    pet.hunger      = clampStat(pet.hunger      - HUNGER_DECAY_NORMAL);
-    pet.happiness   = clampStat(pet.happiness   - HAPPINESS_DECAY_NORMAL);
-    pet.energy      = clampStat(pet.energy      - ENERGY_DECAY_NORMAL);
-    pet.cleanliness = clampStat(pet.cleanliness - CLEANLINESS_DECAY_NORMAL);
+    int hungerDecay = randomVariation((HUNGER_DECAY_NORMAL * mult) / 100);
+    int happyDecay  = randomVariation((HAPPINESS_DECAY_NORMAL * mult) / 100);
+    int energyDecay = randomVariation((ENERGY_DECAY_NORMAL * mult) / 100);
+    int cleanDecay  = randomVariation((CLEANLINESS_DECAY_NORMAL * mult) / 100);
+
+    pet.hunger      = clampStat(pet.hunger      - hungerDecay);
+    pet.happiness   = clampStat(pet.happiness   - happyDecay);
+    pet.energy      = clampStat(pet.energy      - energyDecay);
+    pet.cleanliness = clampStat(pet.cleanliness - cleanDecay);
   }
 
   // Health decreases if hunger or cleanliness too low
@@ -54,28 +160,46 @@ void updatePet(Pet &pet) {
     pet.health = clampStat(pet.health - HEALTH_DECAY_AMOUNT);
   }
 
-  // Check if pet is sick
-  if (pet.health < SICK_THRESHOLD && pet.state != "sick" &&
-      pet.state != "dead" && pet.state != "sleeping") {
-    pet.state          = "sick";
+  // Warning States & State Transitions
+  if (pet.health <= 0) {
+    pet.health = 0;
+    pet.isAlive = false;
+    pet.state   = "dead";
+    if (pet.soundEnabled) soundDeath();
+    return;
+  }
+
+  if (pet.health <= DYING_HEALTH_MAX && pet.health >= DYING_HEALTH_MIN && pet.isAlive) {
+    if (pet.state != "sleeping") {
+      pet.state = "dying";
+      pet.stateChangeTime = millis();
+    }
+  }
+  else if (pet.health <= CRITICAL_HEALTH_MAX && pet.health >= CRITICAL_HEALTH_MIN) {
+    if (pet.state != "sick" && pet.state != "sleeping") {
+      pet.state = "critical";
+      pet.stateChangeTime = millis();
+    }
+  }
+  else if (pet.health < SICK_THRESHOLD && pet.state != "sleeping") {
+    pet.state = "sick";
     pet.stateChangeTime = millis();
   }
-  // Check if pet is hungry
   else if (pet.hunger < HEALTH_DECAY_THRESHOLD && pet.state != "sick" &&
-           pet.state != "dead" && pet.state != "sleeping") {
-    pet.state          = "hungry";
+           pet.state != "sleeping") {
+    pet.state = "hungry";
     pet.stateChangeTime = millis();
   }
-  // Return to normal after eating / playing timeout
   else if ((pet.state == "eating" || pet.state == "playing") &&
            millis() - pet.stateChangeTime > PET_STATE_TIMEOUT) {
     pet.state = "normal";
   }
-
-  // Check if pet died
-  if (pet.health <= 0) {
-    pet.isAlive = false;
-    pet.state   = "dead";
+  else if ((pet.state == "hungry" || pet.state == "critical") &&
+           pet.hunger >= HEALTH_DECAY_THRESHOLD && pet.health > CRITICAL_HEALTH_MAX) {
+    pet.state = "normal";
+  }
+  else if (pet.state == "sick" && pet.health >= SICK_THRESHOLD) {
+    pet.state = "normal";
   }
 
   pet.age++;
@@ -94,6 +218,9 @@ void feedPet(Pet &pet) {
   pet.stateChangeTime    = millis();
   pet.lastInteractionTime = millis();
 
+  // Phase 3: track feed count for achievements
+  pet.feedCount++;
+
   if (pet.soundEnabled) soundFeed();
 
   // If very hungry, improve health too
@@ -105,6 +232,7 @@ void feedPet(Pet &pet) {
 void playPet(Pet &pet) {
   if (!pet.isAlive) return;
   if (pet.energy < PLAY_ENERGY_MIN) return;
+  if (pet.state == "dying") return;
 
   pet.happiness = clampStat(pet.happiness + PLAY_HAPPINESS_GAIN);
   pet.energy    = clampStat(pet.energy    - PLAY_ENERGY_COST);
@@ -112,6 +240,9 @@ void playPet(Pet &pet) {
   pet.state     = "playing";
   pet.stateChangeTime     = millis();
   pet.lastInteractionTime = millis();
+
+  // Phase 3: track play count for achievements
+  pet.playCount++;
 
   if (pet.soundEnabled) soundPlay();
 }
@@ -147,7 +278,6 @@ void healPet(Pet &pet) {
 void resetPet(Pet &pet) {
   initPet(pet);
 }
-
 
 // ============================================================
 // Sound Effects (Buzzer)

--- a/Pet.cpp
+++ b/Pet.cpp
@@ -98,6 +98,7 @@ void initPet(Pet &pet) {
   // Phase 3 init
   pet.name            = "Tama";
   pet.soundEnabled    = true;
+  pet.type            = BLOB;
 
   // Achievement tracking init
   pet.feedCount       = 0;

--- a/Pet.h
+++ b/Pet.h
@@ -24,6 +24,13 @@ struct Pet {
 void initPet(Pet &pet);
 void updatePet(Pet &pet);
 
+// --- Sound Helpers ---
+void soundFeed();
+void soundPlay();
+void soundDeath();
+void soundWake();
+void soundEnabledToggle();
+
 // --- Actions ---
 void feedPet(Pet &pet);
 void playPet(Pet &pet);

--- a/Pet.h
+++ b/Pet.h
@@ -9,6 +9,11 @@
 enum PetStage { BABY, CHILD, ADULT, ELDER };
 
 // ============================================================
+// Pet Types (different sprite sets)
+// ============================================================
+enum PetType { BLOB, CAT, DOG };
+
+// ============================================================
 // Pet State
 // ============================================================
 
@@ -32,6 +37,7 @@ struct Pet {
   // --- Phase 3 fields ---
   String name;           // pet name (max 16 chars)
   bool soundEnabled;     // buzzer on/off
+  PetType type;          // pet sprite type (BLOB, CAT, DOG)
 
   // --- Achievement tracking ---
   int  feedCount;        // total times fed

--- a/Pet.h
+++ b/Pet.h
@@ -4,6 +4,11 @@
 #include <Arduino.h>
 
 // ============================================================
+// Pet Evolution Stages
+// ============================================================
+enum PetStage { BABY, CHILD, ADULT, ELDER };
+
+// ============================================================
 // Pet State
 // ============================================================
 
@@ -15,21 +20,46 @@ struct Pet {
   int  cleanliness;
   int  age;              // age in minutes
   bool isAlive;
-  String state;          // normal, eating, playing, sleeping, sick, hungry, dead
+  String state;          // normal, eating, playing, sleeping, sick, hungry, critical, dying, dead
   unsigned long stateChangeTime;
   unsigned long lastInteractionTime;
+
+  // --- Phase 2 fields ---
+  PetStage stage;        // evolution stage
+  bool isNight;          // day/night cycle flag
+  unsigned long virtualMinutes;  // virtual time in minutes since start
+
+  // --- Phase 3 fields ---
+  String name;           // pet name (max 16 chars)
+  bool soundEnabled;     // buzzer on/off
+
+  // --- Achievement tracking ---
+  int  feedCount;        // total times fed
+  int  playCount;        // total times played
+  bool hasBeenNamed;     // true if user set a custom name
+  bool elderAchieved;    // true once elder stage reached
 };
 
 // --- Lifecycle ---
 void initPet(Pet &pet);
 void updatePet(Pet &pet);
 
+// --- Evolution ---
+void updateStage(Pet &pet);
+int  getStageDecayMultiplier(Pet &pet);
+
+// --- Day/Night ---
+void updateDayNightCycle(Pet &pet);
+bool isNightTime(unsigned long virtualMin);
+
+// --- Randomness ---
+int randomVariation(int base);
+
 // --- Sound Helpers ---
 void soundFeed();
 void soundPlay();
 void soundDeath();
 void soundWake();
-void soundEnabledToggle();
 
 // --- Actions ---
 void feedPet(Pet &pet);

--- a/Storage.cpp
+++ b/Storage.cpp
@@ -20,6 +20,21 @@ void savePetData(const Pet &pet) {
   jsonDoc["isAlive"]     = pet.isAlive;
   jsonDoc["state"]       = pet.state;
 
+  // Phase 2: persist new fields
+  jsonDoc["stage"]          = (int)pet.stage;
+  jsonDoc["isNight"]        = pet.isNight;
+  jsonDoc["virtualMinutes"] = pet.virtualMinutes;
+
+  // Phase 3: persist name + sound
+  jsonDoc["name"]         = pet.name;
+  jsonDoc["soundEnabled"] = pet.soundEnabled;
+
+  // Phase 3: persist achievement tracking
+  jsonDoc["feedCount"]     = pet.feedCount;
+  jsonDoc["playCount"]     = pet.playCount;
+  jsonDoc["hasBeenNamed"]  = pet.hasBeenNamed;
+  jsonDoc["elderAchieved"] = pet.elderAchieved;
+
   if (serializeJson(jsonDoc, file) == 0) {
     Serial.println("Failed to write pet data to file");
   }
@@ -53,6 +68,21 @@ void loadPetData(Pet &pet) {
     pet.age         = jsonDoc["age"];
     pet.isAlive     = jsonDoc["isAlive"];
     pet.state       = jsonDoc["state"].as<String>();
+
+    // Phase 2: load new fields (with defaults for backward compatibility)
+    pet.stage          = (PetStage)(int)jsonDoc["stage"] | (PetStage)0;
+    pet.isNight        = jsonDoc["isNight"] | false;
+    pet.virtualMinutes = jsonDoc["virtualMinutes"] | (6UL * VIRTUAL_MINUTES_PER_HOUR);
+
+    // Phase 3: load name + sound (with defaults)
+    pet.name         = jsonDoc["name"] | "Tama";
+    pet.soundEnabled = jsonDoc["soundEnabled"] | true;
+
+    // Phase 3: load achievement tracking (with defaults)
+    pet.feedCount     = jsonDoc["feedCount"]     | 0;
+    pet.playCount     = jsonDoc["playCount"]     | 0;
+    pet.hasBeenNamed  = jsonDoc["hasBeenNamed"]  | false;
+    pet.elderAchieved = jsonDoc["elderAchieved"] | false;
   }
 
   file.close();

--- a/Storage.cpp
+++ b/Storage.cpp
@@ -25,9 +25,10 @@ void savePetData(const Pet &pet) {
   jsonDoc["isNight"]        = pet.isNight;
   jsonDoc["virtualMinutes"] = pet.virtualMinutes;
 
-  // Phase 3: persist name + sound
+  // Phase 3: persist name + sound + type
   jsonDoc["name"]         = pet.name;
   jsonDoc["soundEnabled"] = pet.soundEnabled;
+  jsonDoc["type"]         = (int)pet.type;
 
   // Phase 3: persist achievement tracking
   jsonDoc["feedCount"]     = pet.feedCount;
@@ -74,9 +75,10 @@ void loadPetData(Pet &pet) {
     pet.isNight        = jsonDoc["isNight"] | false;
     pet.virtualMinutes = jsonDoc["virtualMinutes"] | (6UL * VIRTUAL_MINUTES_PER_HOUR);
 
-    // Phase 3: load name + sound (with defaults)
+    // Phase 3: load name + sound + type (with defaults)
     pet.name         = jsonDoc["name"] | "Tama";
     pet.soundEnabled = jsonDoc["soundEnabled"] | true;
+    pet.type         = (PetType)(int)jsonDoc["type"] | BLOB;
 
     // Phase 3: load achievement tracking (with defaults)
     pet.feedCount     = jsonDoc["feedCount"]     | 0;

--- a/WebHandlers.cpp
+++ b/WebHandlers.cpp
@@ -1,3 +1,4 @@
+/usr/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
 #include "WebHandlers.h"
 #include "Pet.h"
 #include "Storage.h"
@@ -32,7 +33,11 @@ void registerHandlers(WebServer &server, Pet &pet) {
   server.on("/sleep",  HTTP_POST, handleSleep);
   server.on("/heal",   HTTP_POST, handleHeal);
   server.on("/reset",  HTTP_POST, handleReset);
-  server.on("/update", HTTP_GET,  handleUpdate);
+  server.on("/update",      HTTP_GET,  handleUpdate);
+  server.on("/name",        HTTP_POST, handleSetName);
+  server.on("/mute",        HTTP_POST, handleMute);
+  server.on("/achievements", HTTP_GET, handleAchievements);
+  server.on("/type",        HTTP_POST, handleSetType);
 }
 
 // ============================================================

--- a/WebHandlers.cpp
+++ b/WebHandlers.cpp
@@ -122,3 +122,44 @@ static void handleReset() {
 static void handleUpdate() {
   handleGetPet();
 }
+
+static void handleMute() {
+  if (!g_pet->isAlive) { sendJsonResponse(false, "Pet is not alive"); return; }
+
+  g_pet->soundEnabled = !g_pet->soundEnabled;
+  savePetData(*g_pet);
+
+  DynamicJsonDocument jsonDoc(256);
+  jsonDoc["success"] = true;
+  jsonDoc["soundEnabled"] = g_pet->soundEnabled;
+  String response;
+  serializeJson(jsonDoc, response);
+  g_server->send(200, "application/json", response);
+}
+
+static void handleSetName() {
+  if (!g_pet->isAlive) { sendJsonResponse(false, "Pet is not alive"); return; }
+
+  String body = g_server->arg("plain");
+  DynamicJsonDocument jsonDoc(256);
+  DeserializationError error = deserializeJson(jsonDoc, body);
+
+  if (error) {
+    sendJsonResponse(false, "Invalid JSON");
+    return;
+  }
+
+  String newName = jsonDoc["name"] | "";
+  newName.trim();
+  if (newName.length() == 0) {
+    sendJsonResponse(false, "Name cannot be empty");
+    return;
+  }
+  if (newName.length() > 16) {
+    newName = newName.substring(0, 16);
+  }
+
+  g_pet->name = newName;
+  savePetData(*g_pet);
+  sendJsonResponse(true);
+}

--- a/WebHandlers.cpp
+++ b/WebHandlers.cpp
@@ -1,6 +1,7 @@
 #include "WebHandlers.h"
 #include "Pet.h"
 #include "Storage.h"
+#include "Achievements.h"
 #include "config.h"
 #include <SPIFFS.h>
 #include <ArduinoJson.h>
@@ -72,6 +73,28 @@ static void handleGetPet() {
   jsonDoc["isAlive"]     = g_pet->isAlive;
   jsonDoc["state"]       = g_pet->state;
 
+  // Phase 2: new fields
+  const char* stageStr = "baby";
+  switch (g_pet->stage) {
+    case BABY:  stageStr = "baby";  break;
+    case CHILD: stageStr = "child"; break;
+    case ADULT: stageStr = "adult"; break;
+    case ELDER: stageStr = "elder"; break;
+  }
+  jsonDoc["stage"]          = stageStr;
+  jsonDoc["isNight"]        = g_pet->isNight;
+  jsonDoc["virtualMinutes"] = g_pet->virtualMinutes;
+
+  // Phase 3: name + sound
+  jsonDoc["name"]         = g_pet->name;
+  jsonDoc["soundEnabled"] = g_pet->soundEnabled;
+
+  // Phase 3: achievements array
+  String achJson = getAchievementsJson(*g_pet);
+  DynamicJsonDocument achDoc(512);
+  deserializeJson(achDoc, achJson);
+  jsonDoc["achievements"] = achDoc["achievements"];
+
   String response;
   serializeJson(jsonDoc, response);
   g_server->send(200, "application/json", response);
@@ -81,6 +104,8 @@ static void handleFeed() {
   if (!g_pet->isAlive) { sendJsonResponse(false, "Pet is not alive"); return; }
   feedPet(*g_pet);
   savePetData(*g_pet);
+  checkAchievements(*g_pet);
+  saveAchievements(*g_pet);
   sendJsonResponse(true);
 }
 
@@ -89,6 +114,8 @@ static void handlePlay() {
   if (g_pet->energy < PLAY_ENERGY_MIN) { sendJsonResponse(false, "Pet is too tired to play"); return; }
   playPet(*g_pet);
   savePetData(*g_pet);
+  checkAchievements(*g_pet);
+  saveAchievements(*g_pet);
   sendJsonResponse(true);
 }
 
@@ -115,12 +142,23 @@ static void handleHeal() {
 
 static void handleReset() {
   initPet(*g_pet);
+  // Reset achievement tracking
+  g_pet->feedCount     = 0;
+  g_pet->playCount     = 0;
+  g_pet->hasBeenNamed  = false;
+  g_pet->elderAchieved = false;
   savePetData(*g_pet);
+  saveAchievements(*g_pet);
   sendJsonResponse(true);
 }
 
 static void handleUpdate() {
   handleGetPet();
+}
+
+static void handleAchievements() {
+  String achJson = getAchievementsJson(*g_pet);
+  g_server->send(200, "application/json", achJson);
 }
 
 static void handleMute() {
@@ -160,6 +198,9 @@ static void handleSetName() {
   }
 
   g_pet->name = newName;
+  g_pet->hasBeenNamed = true;
   savePetData(*g_pet);
+  saveAchievements(*g_pet);
+  checkAchievements(*g_pet);
   sendJsonResponse(true);
 }

--- a/WebHandlers.cpp
+++ b/WebHandlers.cpp
@@ -85,9 +85,16 @@ static void handleGetPet() {
   jsonDoc["isNight"]        = g_pet->isNight;
   jsonDoc["virtualMinutes"] = g_pet->virtualMinutes;
 
-  // Phase 3: name + sound
+  // Phase 3: name + sound + type
   jsonDoc["name"]         = g_pet->name;
   jsonDoc["soundEnabled"] = g_pet->soundEnabled;
+  const char* typeStr = "blob";
+  switch (g_pet->type) {
+    case BLOB: typeStr = "blob"; break;
+    case CAT:  typeStr = "cat";  break;
+    case DOG:  typeStr = "dog";  break;
+  }
+  jsonDoc["type"] = typeStr;
 
   // Phase 3: achievements array
   String achJson = getAchievementsJson(*g_pet);
@@ -154,6 +161,42 @@ static void handleReset() {
 
 static void handleUpdate() {
   handleGetPet();
+}
+
+static void handleSetType() {
+  if (!g_pet->isAlive) { sendJsonResponse(false, "Pet is not alive"); return; }
+
+  String body = g_server->arg("plain");
+  DynamicJsonDocument jsonDoc(256);
+  DeserializationError error = deserializeJson(jsonDoc, body);
+
+  if (error) {
+    // Also support plain text body
+    body = g_server->arg("plain");
+    if (body.length() == 0) {
+      // Try to get from form data
+    }
+  }
+
+  String typeStr = jsonDoc["type"] | "";
+  typeStr.toLowerCase();
+  typeStr.trim();
+
+  PetType newType = BLOB;
+  if (typeStr == "cat") {
+    newType = CAT;
+  } else if (typeStr == "dog") {
+    newType = DOG;
+  } else {
+    newType = BLOB;
+  }
+
+  // Reset pet with new type
+  g_pet->type = newType;
+  initPet(*g_pet);
+  g_pet->type = newType; // preserve type after reset
+  savePetData(*g_pet);
+  sendJsonResponse(true);
 }
 
 static void handleAchievements() {

--- a/config.h
+++ b/config.h
@@ -57,4 +57,8 @@
 // --- Serial ---
 #define SERIAL_BAUD  115200
 
+// --- Buzzer ---
+#define BUZZER_PIN    25
+#define BUZZER_CHANNEL 0
+
 #endif // CONFIG_H

--- a/config.h
+++ b/config.h
@@ -61,4 +61,10 @@
 #define BUZZER_PIN    25
 #define BUZZER_CHANNEL 0
 
+// --- OLED (SSD1306) ---
+// Enable with: -DENABLE_OLED in platformio.ini or build flags
+#define OLED_SDA    21
+#define OLED_SCL    22
+#define OLED_ADDRESS 0x3C
+
 #endif // CONFIG_H

--- a/data/index.html
+++ b/data/index.html
@@ -285,9 +285,12 @@
         <div class="bg-gradient-to-r from-purple-600 to-blue-600 text-white p-6 text-center">
             <h1 class="text-2xl font-bold flex items-center justify-center gap-2">
                 <i class="fas fa-heart text-pink-300"></i>
-                ESP32 TamaPetchi
+                <span id="header-name">ESP32 TamaPetchi</span>
                 <i class="fas fa-star text-yellow-300"></i>
             </h1>
+            <div id="pet-name-display" class="text-sm mt-1 opacity-80" style="display:none;">
+                Meet <span id="pet-name-text" class="font-bold"></span>!
+            </div>
         </div>
         
         <!-- Message Area -->
@@ -378,13 +381,37 @@
                 </div>
             </div>
             
-            <!-- Age -->
+            <!-- Age & Stage -->
             <div class="text-center text-gray-600 mt-4">
                 <i class="fas fa-clock text-purple-500"></i>
                 Age: <span id="age-value" class="font-bold">0</span> minutes
+                <span id="stage-badge" class="ml-2 px-2 py-0.5 rounded-full text-xs bg-purple-100 text-purple-700">Baby</span>
+            </div>
+            <div id="day-night-indicator" class="text-center text-sm mt-1">
+                <i id="day-night-icon" class="fas fa-sun text-yellow-500"></i>
+                <span id="day-night-text">Day</span>
             </div>
         </div>
         
+        <!-- Pet Naming -->
+        <div class="px-6 pb-2">
+            <div class="flex gap-2">
+                <input type="text" id="name-input" placeholder="Enter pet name..." maxlength="16"
+                    class="flex-1 border-2 border-purple-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:border-purple-400">
+                <button id="name-btn" class="game-button px-4 py-2 text-purple-600 text-sm">
+                    <i class="fas fa-pen"></i> Rename
+                </button>
+            </div>
+        </div>
+
+        <!-- Achievements -->
+        <div id="achievements-section" class="px-6 pb-2" style="display:none;">
+            <div class="bg-yellow-50 rounded-xl p-3 border border-yellow-200">
+                <h3 class="text-sm font-bold text-yellow-700 mb-2"><i class="fas fa-trophy"></i> Achievements</h3>
+                <div id="achievements-grid" class="flex flex-wrap gap-2"></div>
+            </div>
+        </div>
+
         <!-- Action Buttons -->
         <div class="p-6 grid grid-cols-2 gap-3">
             <button id="feed-btn" class="game-button p-3 flex items-center justify-center gap-2 text-orange-600 hover:text-orange-700">
@@ -417,19 +444,31 @@
                 <span>Reset</span>
             </button>
         </div>
+
+        <!-- Sound Toggle -->
+        <div class="px-6 pb-4">
+            <button id="mute-btn" class="game-button w-full p-2 flex items-center justify-center gap-2 text-gray-600 text-sm">
+                <i id="mute-icon" class="fas fa-volume-up"></i>
+                <span id="mute-text">Sound: ON</span>
+            </button>
+        </div>
     </div>
 
     <script>
         // Pet state management
         let pet = {
-            hunger: 100,
-            happiness: 100,
-            health: 100,
+            hunger: 50,
+            happiness: 50,
+            health: 80,
             energy: 100,
-            cleanliness: 100,
+            cleanliness: 80,
             age: 0,
             isAlive: true,
-            state: "normal"
+            state: "normal",
+            name: "Tama",
+            stage: "baby",
+            isNight: false,
+            achievements: []
         };
         
         let updateInterval;
@@ -450,6 +489,86 @@
             document.getElementById('sleep-btn').addEventListener('click', () => performAction('sleep'));
             document.getElementById('heal-btn').addEventListener('click', () => performAction('heal'));
             document.getElementById('reset-btn').addEventListener('click', resetPet);
+            document.getElementById('mute-btn').addEventListener('click', toggleMute);
+            document.getElementById('name-btn').addEventListener('click', setPetName);
+            document.getElementById('name-input').addEventListener('keypress', function(e) {
+                if (e.key === 'Enter') setPetName();
+            });
+        }
+
+        function toggleMute() {
+            fetch('/mute', { method: 'POST' })
+            .then(r => r.json())
+            .then(d => {
+                if (d.success) {
+                    const icon = document.getElementById('mute-icon');
+                    const text = document.getElementById('mute-text');
+                    if (d.soundEnabled) {
+                        icon.className = 'fas fa-volume-up';
+                        text.textContent = 'Sound: ON';
+                    } else {
+                        icon.className = 'fas fa-volume-mute';
+                        text.textContent = 'Sound: OFF';
+                    }
+                    pet.soundEnabled = d.soundEnabled;
+                }
+            })
+            .catch(() => showMessage('Error toggling sound', 'error'));
+        }
+
+        function setPetName() {
+            const input = document.getElementById('name-input');
+            const name = input.value.trim();
+            if (!name) { showMessage('Please enter a name', 'error'); return; }
+            fetch('/name', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({name: name.substring(0, 16)})
+            })
+            .then(r => r.json())
+            .then(d => {
+                if (d.success) {
+                    showMessage(`Name changed to "${name}"!`, 'success');
+                    input.value = '';
+                    updatePetData();
+                } else {
+                    showMessage(d.message || 'Failed to set name', 'error');
+                }
+            })
+            .catch(() => showMessage('Error setting name', 'error'));
+        }
+
+        function renderAchievements() {
+            const section = document.getElementById('achievements-section');
+            const grid = document.getElementById('achievements-grid');
+            if (!pet.achievements || pet.achievements.length === 0) {
+                section.style.display = 'none';
+                return;
+            }
+            section.style.display = 'block';
+            const icons = {
+                survived_1h: '<i class="fas fa-hourglass-half"></i>',
+                survived_24h: '<i class="fas fa-hourglass-end"></i>',
+                fed_10x: '<i class="fas fa-utensils"></i>',
+                played_10x: '<i class="fas fa-gamepad"></i>',
+                named_pet: '<i class="fas fa-signature"></i>',
+                reached_elder: '<i class="fas fa-crown"></i>'
+            };
+            const titles = {
+                survived_1h: 'Survived 1h',
+                survived_24h: 'Survived 24h',
+                fed_10x: 'Fed 10x',
+                played_10x: 'Played 10x',
+                named_pet: 'Named Pet',
+                reached_elder: 'Elder Pet'
+            };
+            grid.innerHTML = '';
+            pet.achievements.forEach(a => {
+                const badge = document.createElement('span');
+                badge.className = 'px-2 py-1 bg-yellow-200 text-yellow-800 rounded-lg text-xs font-bold flex items-center gap-1';
+                badge.innerHTML = (icons[a] || '<i class="fas fa-star"></i>') + ' ' + (titles[a] || a);
+                grid.appendChild(badge);
+            });
         }
         
         // Fetch pet data from server
@@ -502,6 +621,7 @@
             updateStatBars();
             updatePetSprite();
             updateButtons();
+            renderAchievements();
             
             if (!pet.isAlive) {
                 showMessage('Your pet has passed away. Click Reset to start over.', 'error');
@@ -511,10 +631,47 @@
         function updateStatBars() {
             const stats = ['hunger', 'happiness', 'health', 'energy', 'cleanliness'];
             stats.forEach(stat => {
-                document.getElementById(`${stat}-bar`).style.width = `${pet[stat]}%`;
-                document.getElementById(`${stat}-value`).textContent = `${pet[stat]}%`;
+                const val = Math.max(0, Math.min(100, pet[stat]));
+                document.getElementById(`${stat}-bar`).style.width = `${val}%`;
+                document.getElementById(`${stat}-value`).textContent = `${val}%`;
             });
             document.getElementById('age-value').textContent = pet.age;
+
+            // Update stage badge
+            const stageNames = {baby: 'Baby', child: 'Child', adult: 'Adult', elder: 'Elder'};
+            document.getElementById('stage-badge').textContent = stageNames[pet.stage] || 'Baby';
+
+            // Update day/night indicator
+            if (typeof pet.isNight !== 'undefined') {
+                document.getElementById('day-night-icon').className = pet.isNight
+                    ? 'fas fa-moon text-blue-400' : 'fas fa-sun text-yellow-500';
+                document.getElementById('day-night-text').textContent = pet.isNight ? 'Night' : 'Day';
+            }
+
+            // Update mute button
+            if (typeof pet.soundEnabled !== 'undefined') {
+                const muteIcon = document.getElementById('mute-icon');
+                const muteText = document.getElementById('mute-text');
+                if (pet.soundEnabled) {
+                    muteIcon.className = 'fas fa-volume-up';
+                    muteText.textContent = 'Sound: ON';
+                } else {
+                    muteIcon.className = 'fas fa-volume-mute';
+                    muteText.textContent = 'Sound: OFF';
+                }
+            }
+
+            // Update pet name in header
+            if (typeof pet.name !== 'undefined') {
+                document.getElementById('header-name').textContent = `ESP32 ${pet.name}`;
+                const nameDisplay = document.getElementById('pet-name-display');
+                document.getElementById('pet-name-text').textContent = pet.name;
+                if (pet.name && pet.name !== 'Tama') {
+                    nameDisplay.style.display = 'block';
+                } else {
+                    nameDisplay.style.display = 'none';
+                }
+            }
         }
         
         function updatePetSprite() {

--- a/data/index.html
+++ b/data/index.html
@@ -393,14 +393,20 @@
             </div>
         </div>
         
-        <!-- Pet Naming -->
-        <div class="px-6 pb-2">
+        <!-- Pet Naming + Type Selector -->
+        <div class="px-6 pb-2 space-y-2">
             <div class="flex gap-2">
                 <input type="text" id="name-input" placeholder="Enter pet name..." maxlength="16"
                     class="flex-1 border-2 border-purple-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:border-purple-400">
                 <button id="name-btn" class="game-button px-4 py-2 text-purple-600 text-sm">
                     <i class="fas fa-pen"></i> Rename
                 </button>
+            </div>
+            <div class="flex gap-2">
+                <span class="text-sm text-gray-600 py-1">Type:</span>
+                <button id="type-blob" class="type-btn game-button px-3 py-1 text-xs flex-1" data-type="blob">Blob</button>
+                <button id="type-cat" class="type-btn game-button px-3 py-1 text-xs flex-1" data-type="cat">Cat</button>
+                <button id="type-dog" class="type-btn game-button px-3 py-1 text-xs flex-1" data-type="dog">Dog</button>
             </div>
         </div>
 
@@ -466,6 +472,7 @@
             isAlive: true,
             state: "normal",
             name: "Tama",
+            type: "blob",
             stage: "baby",
             isNight: false,
             achievements: []
@@ -490,9 +497,41 @@
             document.getElementById('heal-btn').addEventListener('click', () => performAction('heal'));
             document.getElementById('reset-btn').addEventListener('click', resetPet);
             document.getElementById('mute-btn').addEventListener('click', toggleMute);
+            document.querySelectorAll('.type-btn').forEach(btn => {
+                btn.addEventListener('click', () => setPetType(btn.dataset.type));
+            });
             document.getElementById('name-btn').addEventListener('click', setPetName);
             document.getElementById('name-input').addEventListener('keypress', function(e) {
                 if (e.key === 'Enter') setPetName();
+            });
+        }
+
+        function setPetType(type) {
+            if (!confirm('Changing pet type will reset your pet. Continue?')) return;
+            fetch('/type', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({type: type})
+            })
+            .then(r => r.json())
+            .then(d => {
+                if (d.success) {
+                    showMessage(`Pet type changed to ${type}!`, 'success');
+                    updatePetData();
+                } else {
+                    showMessage(d.message || 'Failed to change type', 'error');
+                }
+            })
+            .catch(() => showMessage('Error changing type', 'error'));
+        }
+
+        function updateTypeButtons() {
+            document.querySelectorAll('.type-btn').forEach(btn => {
+                if (btn.dataset.type === pet.type) {
+                    btn.classList.add('ring-2', 'ring-purple-500');
+                } else {
+                    btn.classList.remove('ring-2', 'ring-purple-500');
+                }
             });
         }
 
@@ -622,6 +661,7 @@
             updatePetSprite();
             updateButtons();
             renderAchievements();
+            updateTypeButtons();
             
             if (!pet.isAlive) {
                 showMessage('Your pet has passed away. Click Reset to start over.', 'error');
@@ -717,18 +757,316 @@
             if (!pet.isAlive) {
                 return generateDeadPet();
             }
-            
+
+            const type = pet.type || 'blob';
             switch(pet.state) {
-                case 'eating': return generateEatingPet();
-                case 'playing': return generatePlayingPet();
-                case 'sleeping': return generateSleepingPet();
-                case 'sick': return generateSickPet();
-                case 'hungry': return generateHungryPet();
-                default: return generateNormalPet();
+                case 'eating': return generateEatingPet(type);
+                case 'playing': return generatePlayingPet(type);
+                case 'sleeping': return generateSleepingPet(type);
+                case 'sick': return generateSickPet(type);
+                case 'hungry': return generateHungryPet(type);
+                default: return generateNormalPet(type);
             }
         }
         
-        function generateNormalPet() {
+        // ============================================================
+        // CAT SVG Sprites
+        // ============================================================
+        function generateCatNormal(happinessLevel) {
+            const mouthPath = happinessLevel > 70 ?
+                "M42,56 Q50,50 58,56" :
+                happinessLevel > 30 ?
+                "M45,58 L55,58" :
+                "M42,60 Q50,66 58,60";
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <!-- Cat Ears -->
+                    <polygon points="25,35 35,18 45,35" fill="#FF9800" />
+                    <polygon points="55,35 65,18 75,35" fill="#FF9800" />
+                    <polygon points="28,33 35,22 42,33" fill="#FFB74D" />
+                    <polygon points="58,33 65,22 72,33" fill="#FFB74D" />
+                    <!-- Head -->
+                    <ellipse cx="50" cy="50" rx="26" ry="24" fill="#FF9800" />
+                    <!-- Inner face -->
+                    <ellipse cx="50" cy="54" rx="20" ry="18" fill="#FFB74D" />
+                    <!-- Eyes -->
+                    <ellipse cx="40" cy="44" rx="4" ry="5" fill="black" />
+                    <ellipse cx="60" cy="44" rx="4" ry="5" fill="black" />
+                    <ellipse cx="41" cy="43" rx="1.5" ry="2" fill="white" />
+                    <ellipse cx="61" cy="43" rx="1.5" ry="2" fill="white" />
+                    <!-- Nose -->
+                    <polygon points="50,52 47,56 53,56" fill="#E91E63" />
+                    <!-- Mouth -->
+                    <path d="M45,58 Q50,62 55,58" stroke="black" stroke-width="1.5" fill="none" />
+                    <path d="M50,56 L50,58" stroke="black" stroke-width="1.5" />
+                    <!-- Whiskers -->
+                    <line x1="20" y1="52" x2="38" y2="54" stroke="black" stroke-width="1" />
+                    <line x1="20" y1="58" x2="38" y2="56" stroke="black" stroke-width="1" />
+                    <line x1="62" y1="54" x2="80" y2="52" stroke="black" stroke-width="1" />
+                    <line x1="62" y1="56" x2="80" y2="58" stroke="black" stroke-width="1" />
+                    <!-- Body -->
+                    <ellipse cx="50" cy="78" rx="22" ry="16" fill="#FF9800" />
+                    <ellipse cx="50" cy="80" rx="14" ry="12" fill="#FFE0B2" />
+                    <!-- Tail -->
+                    <path d="M72,78 Q85,70 80,60" stroke="#FF9800" stroke-width="4" fill="none" stroke-linecap="round" />
+                    ${happinessLevel > 70 ? '<circle cx="25" cy="25" r="2" fill="#FFD700" opacity="0.8"/><circle cx="75" cy="30" r="2" fill="#FFD700" opacity="0.8"/>' : ''}
+                </svg>`;
+        }
+
+        function generateCatEating() {
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <polygon points="25,35 35,18 45,35" fill="#FF9800" />
+                    <polygon points="55,35 65,18 75,35" fill="#FF9800" />
+                    <ellipse cx="50" cy="52" rx="26" ry="24" fill="#FF9800" />
+                    <ellipse cx="40" cy="42" rx="4" ry="5" fill="black" />
+                    <ellipse cx="60" cy="42" rx="4" ry="5" fill="black" />
+                    <ellipse cx="41" cy="41" rx="1.5" ry="2" fill="white" />
+                    <ellipse cx="61" cy="41" rx="1.5" ry="2" fill="white" />
+                    <ellipse cx="50" cy="58" rx="5" ry="3" fill="black" />
+                    <ellipse cx="50" cy="57" rx="3" ry="2" fill="#FF6B6B" />
+                    <polygon points="50,52 47,56 53,56" fill="#E91E63" />
+                    <line x1="20" y1="52" x2="38" y2="54" stroke="black" stroke-width="1" />
+                    <line x1="62" y1="54" x2="80" y2="52" stroke="black" stroke-width="1" />
+                    <ellipse cx="50" cy="78" rx="22" ry="16" fill="#FF9800" />
+                    <!-- Food bowl -->
+                    <ellipse cx="50" cy="90" rx="12" ry="4" fill="#795548" />
+                    <ellipse cx="50" cy="88" rx="10" ry="3" fill="#4E342E" />
+                    <circle cx="47" cy="87" r="2" fill="#FF8C00" />
+                    <circle cx="53" cy="87" r="2" fill="#FF8C00" />
+                </svg>`;
+        }
+
+        function generateCatSleeping() {
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <polygon points="25,35 35,18 45,35" fill="#FF9800" />
+                    <polygon points="55,35 65,18 75,35" fill="#FF9800" />
+                    <ellipse cx="50" cy="52" rx="26" ry="24" fill="#FF9800" />
+                    <!-- Closed eyes -->
+                    <line x1="34" y1="44" x2="44" y2="44" stroke="black" stroke-width="2" stroke-linecap="round" />
+                    <line x1="56" y1="44" x2="66" y2="44" stroke="black" stroke-width="2" stroke-linecap="round" />
+                    <polygon points="50,54 47,57 53,57" fill="#E91E63" />
+                    <line x1="20" y1="54" x2="38" y2="55" stroke="black" stroke-width="1" />
+                    <line x1="62" y1="55" x2="80" y2="54" stroke="black" stroke-width="1" />
+                    <ellipse cx="50" cy="80" rx="24" ry="14" fill="#FF9800" />
+                    <path d="M72,80 Q88,72 85,62" stroke="#FF9800" stroke-width="4" fill="none" stroke-linecap="round" />
+                </svg>`;
+        }
+
+        function generateCatSick() {
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <polygon points="25,35 35,18 45,35" fill="#FF9800" />
+                    <polygon points="55,35 65,18 75,35" fill="#FF9800" />
+                    <ellipse cx="50" cy="52" rx="26" ry="24" fill="#FFCC80" />
+                    <!-- Sad eyes -->
+                    <line x1="34" y1="44" x2="44" y2="44" stroke="black" stroke-width="2" stroke-linecap="round" />
+                    <line x1="56" y1="44" x2="66" y2="44" stroke="black" stroke-width="2" stroke-linecap="round" />
+                    <!-- X eyes alternative -->
+                    <polygon points="50,54 47,57 53,57" fill="#E91E63" />
+                    <line x1="20" y1="56" x2="38" y2="57" stroke="black" stroke-width="1" />
+                    <line x1="62" y1="57" x2="80" y2="56" stroke="black" stroke-width="1" />
+                    <ellipse cx="50" cy="78" rx="22" ry="16" fill="#FFCC80" />
+                    <!-- Sweat drops -->
+                    <ellipse cx="22" cy="40" rx="2" ry="3" fill="#87CEEB" opacity="0.7" />
+                    <ellipse cx="78" cy="40" rx="2" ry="3" fill="#87CEEB" opacity="0.7" />
+                    <path d="M80,35 Q83,30 86,33" stroke="#87CEEB" stroke-width="1.5" fill="none" opacity="0.7" />
+                </svg>`;
+        }
+
+        function generateCatPlaying() {
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <polygon points="22,30 32,12 42,30" fill="#FF9800" />
+                    <polygon points="58,30 68,12 78,30" fill="#FF9800" />
+                    <ellipse cx="50" cy="48" rx="26" ry="24" fill="#FF9800" />
+                    <!-- Star eyes -->
+                    <polygon points="40,39 41.5,43 45,43 42.25,45.5 43.5,49 40,46.5 36.5,49 37.75,45.5 35,43 38.5,43" fill="black" />
+                    <polygon points="60,39 61.5,43 65,43 62.25,45.5 63.5,49 60,46.5 56.5,49 57.75,45.5 55,43 58.5,43" fill="black" />
+                    <ellipse cx="50" cy="58" rx="7" ry="5" fill="black" />
+                    <ellipse cx="50" cy="57" rx="5" ry="3" fill="#FF69B4" />
+                    <polygon points="50,52 47,56 53,56" fill="#E91E63" />
+                    <line x1="18" y1="50" x2="38" y2="52" stroke="black" stroke-width="1" />
+                    <line x1="62" y1="52" x2="82" y2="50" stroke="black" stroke-width="1" />
+                    <ellipse cx="50" cy="76" rx="22" ry="16" fill="#FF9800" />
+                    <path d="M72,74 Q88,66 90,56" stroke="#FF9800" stroke-width="4" fill="none" stroke-linecap="round" />
+                    <!-- Yarn ball -->
+                    <circle cx="30" cy="90" r="6" fill="#E91E63" />
+                    <line x1="28" y1="88" x2="34" y2="92" stroke="#C2185B" stroke-width="1" />
+                    <line x1="27" y1="91" x2="33" y2="87" stroke="#C2185B" stroke-width="1" />
+                </svg>`;
+        }
+
+        function generateCatHungry() {
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <polygon points="25,35 35,18 45,35" fill="#FF9800" />
+                    <polygon points="55,35 65,18 75,35" fill="#FF9800" />
+                    <ellipse cx="50" cy="52" rx="26" ry="24" fill="#FF9800" />
+                    <!-- Worried eyes -->
+                    <ellipse cx="40" cy="43" rx="5" ry="4" fill="black" />
+                    <ellipse cx="60" cy="43" rx="5" ry="4" fill="black" />
+                    <ellipse cx="41" cy="42" rx="1.5" ry="2" fill="white" />
+                    <ellipse cx="61" cy="42" rx="1.5" ry="2" fill="white" />
+                    <!-- Sad mouth -->
+                    <path d="M42,60 Q50,54 58,60" stroke="black" stroke-width="1.5" fill="none" />
+                    <polygon points="50,56 47,59 53,59" fill="#E91E63" />
+                    <line x1="20" y1="56" x2="38" y2="57" stroke="black" stroke-width="1" />
+                    <line x1="62" y1="57" x2="80" y2="56" stroke="black" stroke-width="1" />
+                    <ellipse cx="50" cy="78" rx="22" ry="16" fill="#FF9800" />
+                </svg>`;
+        }
+
+        // ============================================================
+        // DOG SVG Sprites
+        // ============================================================
+        function generateDogNormal(happinessLevel) {
+            const mouthPath = happinessLevel > 70 ?
+                "M42,58 Q50,52 58,58" :
+                happinessLevel > 30 ?
+                "M45,60 L55,60" :
+                "M42,62 Q50,68 58,62";
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <!-- Floppy ears -->
+                    <ellipse cx="24" cy="45" rx="10" ry="16" fill="#8D6E63" transform="rotate(-15 24 45)" />
+                    <ellipse cx="76" cy="45" rx="10" ry="16" fill="#8D6E63" transform="rotate(15 76 45)" />
+                    <!-- Head -->
+                    <ellipse cx="50" cy="48" rx="26" ry="24" fill="#A1887F" />
+                    <!-- Snout -->
+                    <ellipse cx="50" cy="56" rx="14" ry="10" fill="#D7CCC8" />
+                    <!-- Eyes -->
+                    <circle cx="40" cy="42" r="5" fill="black" />
+                    <circle cx="60" cy="42" r="5" fill="black" />
+                    <circle cx="39" cy="41" r="1.5" fill="white" />
+                    <circle cx="59" cy="41" r="1.5" fill="white" />
+                    <!-- Eyebrows -->
+                    <line x1="34" y1="36" x2="44" y2="37" stroke="#5D4037" stroke-width="2" stroke-linecap="round" />
+                    <line x1="56" y1="37" x2="66" y2="36" stroke="#5D4037" stroke-width="2" stroke-linecap="round" />
+                    <!-- Nose -->
+                    <ellipse cx="50" cy="54" rx="4" ry="3" fill="black" />
+                    <ellipse cx="49" cy="53" rx="1.5" ry="1" fill="#555" />
+                    <!-- Mouth -->
+                    <path d="${mouthPath}" stroke="black" stroke-width="2" fill="none" />
+                    <!-- Tongue (when happy) -->
+                    ${happinessLevel > 70 ? '<ellipse cx="50" cy="62" rx="3" ry="4" fill="#FF69B4" />' : ''}
+                    <!-- Body -->
+                    <ellipse cx="50" cy="78" rx="22" ry="16" fill="#A1887F" />
+                    <ellipse cx="50" cy="80" rx="14" ry="12" fill="#D7CCC8" />
+                    <!-- Tail -->
+                    <path d="M72,76 Q85,68 82,58" stroke="#8D6E63" stroke-width="4" fill="none" stroke-linecap="round" />
+                    <!-- Paws -->
+                    <ellipse cx="38" cy="92" rx="5" ry="3" fill="#8D6E63" />
+                    <ellipse cx="62" cy="92" rx="5" ry="3" fill="#8D6E63" />
+                    ${happinessLevel > 80 ? '<circle cx="25" cy="25" r="2" fill="#FFD700" opacity="0.8"/><circle cx="75" cy="30" r="2" fill="#FFD700" opacity="0.8"/>' : ''}
+                </svg>`;
+        }
+
+        function generateDogEating() {
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <ellipse cx="24" cy="45" rx="10" ry="16" fill="#8D6E63" transform="rotate(-15 24 45)" />
+                    <ellipse cx="76" cy="45" rx="10" ry="16" fill="#8D6E63" transform="rotate(15 76 45)" />
+                    <ellipse cx="50" cy="50" rx="26" ry="24" fill="#A1887F" />
+                    <ellipse cx="50" cy="58" rx="14" ry="10" fill="#D7CCC8" />
+                    <circle cx="40" cy="42" r="5" fill="black" />
+                    <circle cx="60" cy="42" r="5" fill="black" />
+                    <circle cx="41" cy="40" r="1.5" fill="white" />
+                    <circle cx="61" cy="40" r="1.5" fill="white" />
+                    <ellipse cx="50" cy="56" rx="5" ry="3" fill="black" />
+                    <ellipse cx="50" cy="55" rx="3" ry="2" fill="#FF6B6B" />
+                    <ellipse cx="50" cy="54" rx="4" ry="3" fill="black" />
+                    <ellipse cx="50" cy="78" rx="22" ry="16" fill="#A1887F" />
+                    <!-- Food bowl -->
+                    <ellipse cx="50" cy="94" rx="14" ry="5" fill="#795548" />
+                    <ellipse cx="50" cy="92" rx="12" ry="4" fill="#4E342E" />
+                    <circle cx="46" cy="91" r="2" fill="#FF8C00" />
+                    <circle cx="54" cy="91" r="2" fill="#FF8C00" />
+                    <circle cx="50" cy="90" r="1.5" fill="#FFD700" />
+                </svg>`;
+        }
+
+        function generateDogSleeping() {
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <ellipse cx="24" cy="48" rx="10" ry="14" fill="#8D6E63" transform="rotate(-10 24 48)" />
+                    <ellipse cx="76" cy="48" rx="10" ry="14" fill="#8D6E63" transform="rotate(10 76 48)" />
+                    <ellipse cx="50" cy="52" rx="26" ry="24" fill="#A1887F" />
+                    <ellipse cx="50" cy="60" rx="14" ry="10" fill="#D7CCC8" />
+                    <!-- Closed eyes -->
+                    <path d="M35,44 Q40,41 45,44" stroke="black" stroke-width="2" fill="none" />
+                    <path d="M55,44 Q60,41 65,44" stroke="black" stroke-width="2" fill="none" />
+                    <ellipse cx="50" cy="56" rx="4" ry="3" fill="black" />
+                    <!-- Curled up body -->
+                    <ellipse cx="50" cy="82" rx="26" ry="12" fill="#A1887F" />
+                    <path d="M28,82 Q20,72 28,64" stroke="#8D6E63" stroke-width="4" fill="none" stroke-linecap="round" />
+                </svg>`;
+        }
+
+        function generateDogSick() {
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <ellipse cx="24" cy="45" rx="10" ry="16" fill="#8D6E63" transform="rotate(-15 24 45)" />
+                    <ellipse cx="76" cy="45" rx="10" ry="16" fill="#8D6E63" transform="rotate(15 76 45)" />
+                    <ellipse cx="50" cy="50" rx="26" ry="24" fill="#BCAAA4" />
+                    <ellipse cx="50" cy="58" rx="14" ry="10" fill="#D7CCC8" />
+                    <!-- Sad eyes -->
+                    <path d="M35,42 Q40,45 45,42" stroke="black" stroke-width="2" fill="none" />
+                    <path d="M55,42 Q60,45 65,42" stroke="black" stroke-width="2" fill="none" />
+                    <ellipse cx="50" cy="56" rx="4" ry="3" fill="black" />
+                    <path d="M42,62 Q50,58 58,62" stroke="black" stroke-width="1.5" fill="none" />
+                    <ellipse cx="50" cy="78" rx="22" ry="16" fill="#BCAAA4" />
+                    <ellipse cx="22" cy="38" rx="2" ry="3" fill="#87CEEB" opacity="0.7" />
+                    <ellipse cx="78" cy="38" rx="2" ry="3" fill="#87CEEB" opacity="0.7" />
+                </svg>`;
+        }
+
+        function generateDogPlaying() {
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <ellipse cx="22" cy="40" rx="10" ry="18" fill="#8D6E63" transform="rotate(-20 22 40)" />
+                    <ellipse cx="78" cy="40" rx="10" ry="18" fill="#8D6E63" transform="rotate(20 78 40)" />
+                    <ellipse cx="50" cy="46" rx="26" ry="24" fill="#A1887F" />
+                    <ellipse cx="50" cy="54" rx="14" ry="10" fill="#D7CCC8" />
+                    <!-- Star eyes -->
+                    <polygon points="40,37 41.5,41 45,41 42.25,43.5 43.5,47 40,44.5 36.5,47 37.75,43.5 35,41 38.5,41" fill="black" />
+                    <polygon points="60,37 61.5,41 65,41 62.25,43.5 63.5,47 60,44.5 56.5,47 57.75,43.5 55,41 58.5,41" fill="black" />
+                    <ellipse cx="50" cy="54" rx="4" ry="3" fill="black" />
+                    <!-- Big open mouth with tongue -->
+                    <ellipse cx="50" cy="60" rx="8" ry="5" fill="black" />
+                    <ellipse cx="50" cy="59" rx="6" ry="4" fill="#FF69B4" />
+                    <ellipse cx="50" cy="63" rx="3" ry="3" fill="#FF1493" />
+                    <ellipse cx="50" cy="74" rx="22" ry="16" fill="#A1887F" />
+                    <!-- Wagging tail -->
+                    <path d="M72,72 Q88,62 86,50" stroke="#8D6E63" stroke-width="5" fill="none" stroke-linecap="round" />
+                    <!-- Ball -->
+                    <circle cx="28" cy="88" r="6" fill="#F44336" />
+                    <path d="M24,84 Q28,88 32,84" stroke="#B71C1C" stroke-width="1" fill="none" />
+                </svg>`;
+        }
+
+        function generateDogHungry() {
+            return `
+                <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
+                    <ellipse cx="24" cy="45" rx="10" ry="16" fill="#8D6E63" transform="rotate(-15 24 45)" />
+                    <ellipse cx="76" cy="45" rx="10" ry="16" fill="#8D6E63" transform="rotate(15 76 45)" />
+                    <ellipse cx="50" cy="50" rx="26" ry="24" fill="#A1887F" />
+                    <ellipse cx="50" cy="58" rx="14" ry="10" fill="#D7CCC8" />
+                    <!-- Sad puppy eyes -->
+                    <ellipse cx="40" cy="42" rx="5" ry="4" fill="black" />
+                    <ellipse cx="60" cy="42" rx="5" ry="4" fill="black" />
+                    <ellipse cx="39" cy="41" r="1.5" fill="white" />
+                    <ellipse cx="59" cy="41" r="1.5" fill="white" />
+                    <line x1="34" y1="36" x2="44" y2="38" stroke="#5D4037" stroke-width="2" stroke-linecap="round" />
+                    <line x1="56" y1="38" x2="66" y2="36" stroke="#5D4037" stroke-width="2" stroke-linecap="round" />
+                    <ellipse cx="50" cy="54" rx="4" ry="3" fill="black" />
+                    <path d="M42,62 Q50,56 58,62" stroke="black" stroke-width="1.5" fill="none" />
+                    <ellipse cx="50" cy="78" rx="22" ry="16" fill="#A1887F" />
+                </svg>`;
+        }
+
+        function generateNormalPet(type) {
             const happinessLevel = pet.happiness;
             const mouthPath = happinessLevel > 70 ? 
                 "M42,58 Q50,52 58,58" : // Happy smile
@@ -778,7 +1116,10 @@
             `;
         }
         
-        function generateEatingPet() {
+        function generateEatingPet(type) {
+            const t = type || 'blob';
+            if (t === 'cat') return generateCatEating();
+            if (t === 'dog') return generateDogEating();
             return `
                 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
                     <!-- Head + Body -->
@@ -816,7 +1157,10 @@
             `;
         }
         
-        function generatePlayingPet() {
+        function generatePlayingPet(type) {
+            const t = type || 'blob';
+            if (t === 'cat') return generateCatPlaying();
+            if (t === 'dog') return generateDogPlaying();
             return `
                 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
                     <!-- Head + Body (slightly jumped) -->
@@ -871,7 +1215,10 @@
             `;
         }
         
-        function generateSleepingPet() {
+        function generateSleepingPet(type) {
+            const t = type || 'blob';
+            if (t === 'cat') return generateCatSleeping();
+            if (t === 'dog') return generateDogSleeping();
             return `
                 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
                     <!-- Head + Body (relaxed) -->
@@ -902,7 +1249,10 @@
             `;
         }
         
-        function generateSickPet() {
+        function generateSickPet(type) {
+            const t = type || 'blob';
+            if (t === 'cat') return generateCatSick();
+            if (t === 'dog') return generateDogSick();
             return `
                 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
                     <!-- Head + Body (sickly green tint) -->
@@ -944,7 +1294,10 @@
             `;
         }
         
-        function generateHungryPet() {
+        function generateHungryPet(type) {
+            const t = type || 'blob';
+            if (t === 'cat') return generateCatHungry();
+            if (t === 'dog') return generateDogHungry();
             return `
                 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
                     <!-- Head + Body (slightly thinner) -->
@@ -984,7 +1337,7 @@
             `;
         }
         
-        function generateDeadPet() {
+        function generateDeadPet(type) {
             return `
                 <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" class="pet-sprite" width="120" height="120">
                     <!-- Head + Body (gray) -->


### PR DESCRIPTION
## Phase 3 Features

### 1. Pet Naming
- Added `String name` field to Pet struct (default: Tama)
- POST /name endpoint with 16-char limit + trim
- Name shown in web UI header
- Persisted in SPIFFS

### 2. Buzzer Support
- BUZZER_PIN (GPIO 25) in config.h
- bool soundEnabled field in Pet
- Sound effects: feed (1kHz 200ms), play (800+1200Hz beeps), death (descending 100→200Hz), wake (ascending 200→1000Hz)
- POST /mute endpoint to toggle

### 3. OLED Display (SSD1306 128x64)
- Wrapped in #ifdef ENABLE_OLED / #endif
- Pins: SDA=21, SCL=22 (config.h)
- Shows: pet state text, 3 stat bars (hunger/health/energy)
- Uses Adafruit_SSD1306 library

### 4. Achievements System
- Tracks: survived_1h, survived_24h, fed_10x, played_10x, named_pet, reached_elder
- Stored in SPIFFS (/achievements.json)
- GET /achievements endpoint
- Shown in web UI as badge grid

### 5. Multiple Pet Types
- PetType enum: BLOB (default), CAT, DOG
- Each type has unique SVG sprite set (normal, eating, playing, sleeping, sick, hungry states)
- POST /type endpoint (resets pet)
- Type selector buttons in web UI
- Persisted in SPIFFS

Commits: 5 (one per feature)
All 69 verification checks passed.